### PR TITLE
Feature/container attach

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,9 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 import PackageDescription
 
 let package = Package(
     name: "docker-client-swift",
-    platforms: [.macOS(.v10_15)],
+    platforms: [.macOS(.v12)],
     products: [
         .library(name: "DockerClientSwift", targets: ["DockerClientSwift"]),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.18.0"),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.10.0"),
+        // Container attach endpoint
+        .package(url: "https://github.com/vapor/websocket-kit.git", from: "2.4.1"),
         // Only used for parsing the multiple and inconsistent date formats returned by Docker
         .package(url: "https://github.com/marksands/BetterCodable.git", from: "0.4.0"),
         // Some Docker features receive or return TAR archives. Used by tests
@@ -21,6 +23,7 @@ let package = Package(
             dependencies: [
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "AsyncHTTPClient", package: "async-http-client"),
+                .product(name: "WebSocketKit", package: "websocket-kit"),
                 "BetterCodable",
             ]),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.18.0"),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.10.0"),
         // Container attach endpoint
-        .package(url: "https://github.com/vapor/websocket-kit.git", from: "2.4.1"),
+        .package(url: "https://github.com/m-barthelemy/websocket-kit.git", .branch("main")),
         // Only used for parsing the multiple and inconsistent date formats returned by Docker
         .package(url: "https://github.com/marksands/BetterCodable.git", from: "0.4.0"),
         // Some Docker features receive or return TAR archives. Used by tests

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Currently no backwards compatibility is supported; previous versions of the Dock
 |                             | Wait                    | ✅       |   untested  |
 |                             | Filesystem changes      | ✅       |   untested  |
 |                             | Attach                  | 🚧       | basic support <sup>1</sup>|
-|                             | Exec                    | ❌       |  unlikely   |
+|                             | Exec                    | ❌       |  unlikely <sup>2</sup>   |
 |                             |                         |          |             |
 | Images                      | List                    | ✅       |             |
 |                             | Inspect                 | ✅       |             |
@@ -78,7 +78,7 @@ Currently no backwards compatibility is supported; previous versions of the Dock
 |                             | Create                  | ✅       |             |
 |                             | Delete                  | ✅       |             |
 |                             | Prune                   | ✅       |             |
-|                             | (Dis)connect container  | 🚧       |    WIP <sup>2</sup>|
+|                             | (Dis)connect container  | 🚧       |    WIP <sup>3</sup>|
 |                             |                         |          |             |
 | Volumes                     | List                    | ✅       |             |
 |                             | Inspect                 | ✅       |             |
@@ -129,7 +129,9 @@ Note: various Docker endpoints such as list or prune support *filters*. These ar
 
 <sup>1</sup> Attach is currently not supported when connecting to Docker via local Unix socket.
 
-<sup>2</sup> Only Disconnect is currently implemented.
+<sup>2</sup> Docker exec is using an unconventional protocol that requires raw access to the socket. Significant work required to support it.
+
+<sup>3</sup> Only Disconnect is currently implemented.
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Currently no backwards compatibility is supported; previous versions of the Dock
 |                             | Create                  | ✅       |             |
 |                             | Delete                  | ✅       |             |
 |                             | Prune                   | ✅       |             |
-|                             | (Dis)connect container  | 🚧       |    WIP      |
+|                             | (Dis)connect container  | 🚧       |    WIP <sup>2</sup>|
 |                             |                         |          |             |
 | Volumes                     | List                    | ✅       |             |
 |                             | Inspect                 | ✅       |             |
@@ -128,6 +128,9 @@ Currently no backwards compatibility is supported; previous versions of the Dock
 Note: various Docker endpoints such as list or prune support *filters*. These are currently not implemented.
 
 <sup>1</sup> Attach is currently not supported when connecting to Docker via local Unix socket.
+
+<sup>2</sup> Only Disconnect is currently implemented.
+
 
 ## Installation
 ### Package.swift 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Currently no backwards compatibility is supported; previous versions of the Dock
 |                             | Prune                   | ✅       |             |
 |                             | Wait                    | ✅       |   untested  |
 |                             | Filesystem changes      | ✅       |   untested  |
-|                             | Attach                  | 🚧       |    WIP      |
+|                             | Attach                  | 🚧       | basic support <sup>1</sup>|
 |                             | Exec                    | ❌       |  unlikely   |
 |                             |                         |          |             |
 | Images                      | List                    | ✅       |             |
@@ -127,6 +127,7 @@ Currently no backwards compatibility is supported; previous versions of the Dock
 
 Note: various Docker endpoints such as list or prune support *filters*. These are currently not implemented.
 
+<sup>1</sup> Attach is currently not supported when connecting to Docker via local Unix socket.
 
 ## Installation
 ### Package.swift 

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ let docker = DockerClient(
   
   Let's create a container that defaults to running a shell, and attach to it:
   ```swift
-  let _ = try await docker.images.pull(byName: "alpine", tag: "latest")
+  let _ = try await docker.images.pull(byIdentifier: "alpine:latest")
   let spec = ContainerSpec(
       config: .init(
           attachStdin: true,

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Currently no backwards compatibility is supported; previous versions of the Dock
 |                             | Get processes (top)     | ✅       |             |
 |                             | Delete                  | ✅       |             |
 |                             | Prune                   | ✅       |             |
-|                             | Wait                    | ✅       |   untested  |
-|                             | Filesystem changes      | ✅       |   untested  |
+|                             | Wait                    | ✅       | untested    |
+|                             | Filesystem changes      | ✅       | untested    |
 |                             | Attach                  | 🚧       | basic support <sup>1</sup>|
-|                             | Exec                    | ❌       |  unlikely <sup>2</sup>   |
+|                             | Exec                    | ❌       | unlikely <sup>2</sup>|
 |                             |                         |          |             |
 | Images                      | List                    | ✅       |             |
 |                             | Inspect                 | ✅       |             |
@@ -50,7 +50,7 @@ Currently no backwards compatibility is supported; previous versions of the Dock
 |                             | Build                   | ✅       | basic support |
 |                             | Tag                     | ✅       |             |
 |                             | Push                    | ✅       |             |
-|                             | Create (container commit)| ❌       |             |
+|                             | Create (container commit)| ❌       | TBD         |
 |                             | Delete                  | ✅       |             |
 |                             | Prune                   | ✅       |             |
 |                             |                         |          |             |
@@ -78,7 +78,7 @@ Currently no backwards compatibility is supported; previous versions of the Dock
 |                             | Create                  | ✅       |             |
 |                             | Delete                  | ✅       |             |
 |                             | Prune                   | ✅       |             |
-|                             | (Dis)connect container  | 🚧       |    WIP <sup>3</sup>|
+|                             | (Dis)connect container  | 🚧       | WIP <sup>3</sup>|
 |                             |                         |          |             |
 | Volumes                     | List                    | ✅       |             |
 |                             | Inspect                 | ✅       |             |
@@ -108,10 +108,10 @@ Currently no backwards compatibility is supported; previous versions of the Dock
 |                             | Install                 | ✅       |             |
 |                             | Remove                  | ✅       |             |
 |                             | Enable/disable          | ✅       |             |
-|                             | Upgrade                 | ✅       |   untested  |
-|                             | Configure               | ✅       |   untested  |
-|                             | Create                  | ❌       |      TBD    |
-|                             | Push                    | ❌       |      TBD    |
+|                             | Upgrade                 | ✅       | untested    |
+|                             | Configure               | ✅       | untested    |
+|                             | Create                  | ❌       | TBD         |
+|                             | Push                    | ❌       | TBD         |
 |                             |                         |          |             |
 | Registries                  | Login                   | ✅       | basic support |
 |                             |                         |          |             |
@@ -127,9 +127,9 @@ Currently no backwards compatibility is supported; previous versions of the Dock
 
 Note: various Docker endpoints such as list or prune support *filters*. These are currently not implemented.
 
-<sup>1</sup> Attach is currently not supported when connecting to Docker via local Unix socket.
+<sup>1</sup> Attach is currently not supported when connecting to Docker via local Unix socket, or when using a proxy.
 
-<sup>2</sup> Docker exec is using an unconventional protocol that requires raw access to the socket. Significant work required to support it.
+<sup>2</sup> Docker exec is using an unconventional protocol that requires raw access to the TCP socket. Significant work needed in order to support it.
 
 <sup>3</sup> Only Disconnect is currently implemented.
 

--- a/Sources/DockerClientSwift/APIs/DockerClient+Container.swift
+++ b/Sources/DockerClientSwift/APIs/DockerClient+Container.swift
@@ -113,11 +113,11 @@ extension DockerClient {
         /// Gets the logs of a container.
         /// - Parameters:
         ///   - container: Instance of an `Container`.
-        ///   - stdErr: whether to return log lines from the standard error.
-        ///   - stdOut: whether to return log lines from the standard output.
-        ///   - timestamps: whether to return the timestamp of each log line
-        ///   - follow: whether to wait for new logs to become available and stream them.
-        ///   - tail: number of last existing log lines to return. Default: all.
+        ///   - stdErr: Whether to return log lines from the standard error.
+        ///   - stdOut: Whether to return log lines from the standard output.
+        ///   - timestamps: Whether to return the timestamp of each log line
+        ///   - follow: Whether to wait for new logs to become available and stream them.
+        ///   - tail: Number of last existing log lines to return. Default: all.
         /// - Throws: Errors that can occur when executing the request.
         /// - Returns: Returns  a  sequence of `DockerLogEntry`.
         public func logs(container: Container, stdErr: Bool = true, stdOut: Bool = true, timestamps: Bool = true, follow: Bool = false, tail: UInt? = nil, since: Date = .distantPast, until: Date = .distantFuture) async throws -> AsyncThrowingStream<DockerLogEntry, Error> {
@@ -140,6 +140,19 @@ extension DockerClient {
             )
             
             return try await endpoint.map(response: response, tty: container.config.tty)
+        }
+        
+        /// Attaches to a container. Allows to retrieve a stream of the container output, and sending commands if it listens on the standard input.
+        /// - Parameters:
+        ///   - container: Instance of an `Container`.
+        ///   - stream: Whether to return stream
+        ///   - logs: Whether to return log lines from the standard output.
+        ///   - detachKeys: Override the key sequence for detaching a container. Format is a single character `[a-Z]`, or` ctrl-<value>` where `<value>` is one of: a-z, @, ^, [, ,, or _.
+        /// - Throws: Errors that can occur when executing the request.
+        /// - Returns: Returns  a `ContainerAttach` allowing to fetch the container output as well as sending input/commands to it.
+        public func attach(container: Container, stream: Bool, logs: Bool, detachKeys: String? = nil) async throws -> ContainerAttach {
+            let ep = ContainerAttachEndpoint(client: client, nameOrId: container.id, stream: true, logs: false)
+            return try await ep.connect()
         }
         
         /// Deletes all stopped containers.

--- a/Sources/DockerClientSwift/APIs/DockerClient.swift
+++ b/Sources/DockerClientSwift/APIs/DockerClient.swift
@@ -7,7 +7,7 @@ import Logging
 
 /// The entry point for Docker client commands.
 public class DockerClient {
-    private let apiVersion = "v1.41"
+    internal let apiVersion = "v1.41"
     private let headers = HTTPHeaders([
         ("Host", "localhost"), // Required by Docker
         ("Accept", "application/json;charset=utf-8"),
@@ -15,8 +15,8 @@ public class DockerClient {
     ])
     private let decoder: JSONDecoder
     
-    private let deamonURL: URL
-    private let tlsConfig: TLSConfiguration?
+    internal let deamonURL: URL
+    internal let tlsConfig: TLSConfiguration?
     private let client: HTTPClient
     private let logger: Logger
     

--- a/Sources/DockerClientSwift/APIs/DockerClient.swift
+++ b/Sources/DockerClientSwift/APIs/DockerClient.swift
@@ -17,7 +17,7 @@ public class DockerClient {
     
     internal let deamonURL: URL
     internal let tlsConfig: TLSConfiguration?
-    private let client: HTTPClient
+    internal let client: HTTPClient
     private let logger: Logger
     
     
@@ -64,13 +64,13 @@ public class DockerClient {
         }
     
     /// The client needs to be shutdown otherwise it can crash on exit.
-    /// - Throws: Throws an error if the `HTTPClient` can not be shutdown.
+    /// - Throws: Throws an error if the `DockerClient` can not be shutdown.
     public func syncShutdown() throws {
         try client.syncShutdown()
     }
     
     /// The client needs to be shutdown otherwise it can crash on exit.
-    /// - Throws: Throws an error if the `HTTPClient` can not be shutdown.
+    /// - Throws: Throws an error if the `DockerClient` can not be shutdown.
     public func shutdown() async throws {
         try await client.shutdown()
     }

--- a/Sources/DockerClientSwift/Endpoints/Containers/ContainerAttachEndpoint.swift
+++ b/Sources/DockerClientSwift/Endpoints/Containers/ContainerAttachEndpoint.swift
@@ -1,0 +1,107 @@
+import NIO
+import NIOHTTP1
+import WebSocketKit
+import Foundation
+
+class ContainerAttachEndpoint {
+    typealias Body = NoBody
+    typealias Response = AsyncThrowingStream<ByteBuffer, Error>
+    
+    var method: HTTPMethod = .GET
+    
+    private let nameOrId: String
+    let stream: Bool
+    let stdin: Bool
+    let stdout: Bool
+    let stderr: Bool
+
+    var path: String {
+        """
+        containers/\(containerId)/attach/ws\
+        ?stdin=\(stdin)\
+        &stdout=\(stdout)\
+        &stderr=\(stderr)\
+        &stream=\(stream)
+        """
+    }
+
+    
+    init(nameOrId: String, stream: Bool, stdin: Bool, stdout: Bool, stderr: Bool) {
+        self.nameOrId = nameOrId
+        self.stream = stream
+        self.stdin = stdin
+        self.stdout = stdout
+        self.stderr = stderr
+    }
+    
+
+    /// Extracts a log entry/line for a container not having a TTY
+    private func getEntryNoTty(buffer: inout ByteBuffer, timestamps: Bool) throws -> DockerLogEntry {
+        let timestampLen = timestamps ? 31 : 0
+        
+        guard let sourceRaw: UInt8 = buffer.readInteger(endianness: .big, as: UInt8.self) else {
+            throw DockerLogDecodingError.dataCorrupted("Unable to read log entry source stream header")
+        }
+        let msgSource = DockerLogEntry.Source.init(rawValue: sourceRaw) ?? .stdout
+        let _ = buffer.readBytes(length: 3) // 3 unused bytes
+        
+        guard let msgSize: UInt32 = buffer.readInteger(endianness: .big, as: UInt32.self) else {
+            throw DockerLogDecodingError.dataCorrupted("Unable to read log size header")
+        }
+        
+        guard msgSize > 0 else {
+            throw DockerLogDecodingError.noMessageFound
+        }
+        if buffer.readableBytes < msgSize {
+            // TODO: does this happen during normal logs streaming behavior?
+            throw DockerLogDecodingError.dataCorrupted("Readable bytes (\(buffer.readableBytes)) is less than msgSize (\(msgSize))")
+        }
+        
+        var timestamp: Date? = nil
+        var msgBuffer = ByteBuffer.init(bytes: buffer.readBytes(length: Int(msgSize))!)
+        if timestamps {
+            guard let timestampRaw = msgBuffer.readString(length: timestampLen, encoding: .utf8) else {
+                throw DockerLogDecodingError.noTimestampFound
+            }
+            guard let timestampTry = GetContainerLogsEndpoint.formatter.date(from: String(timestampRaw)) else {
+                throw DockerLogDecodingError.timestampCorrupted
+            }
+            timestamp = timestampTry
+        }
+        guard let message = msgBuffer.readString(length: msgBuffer.readableBytes - 1, encoding: .utf8) else {
+            throw  DockerLogDecodingError.dataCorrupted("Unable to parse log message as String")
+        }
+        
+        return DockerLogEntry(source: msgSource, timestamp: timestamp, message: message)
+    }
+    
+    /// Extracts a log entry/line for a container having a TTY
+    private func getEntryTty(buffer: inout ByteBuffer, timestamps: Bool) throws -> [DockerLogEntry] {
+        let timestampLen = timestamps ? 31 : 0
+        var logEntries: [DockerLogEntry] = []
+        
+        let data = buffer.readData(length: buffer.readableBytes)!
+        let lines = data.split(separator: 10 /* ascii code for \n */)
+        for line in lines {
+            var timestamp: Date? = nil
+            var msgBuffer = ByteBuffer(data: line)
+            if timestamps {
+                guard let timestampRaw = msgBuffer.readString(length: timestampLen, encoding: .utf8) else {
+                    throw DockerLogDecodingError.noTimestampFound
+                }
+                guard let timestampTry = GetContainerLogsEndpoint.formatter.date(from: String(timestampRaw)) else {
+                    throw DockerLogDecodingError.timestampCorrupted
+                }
+                timestamp = timestampTry
+            }
+            guard let message = msgBuffer.readString(length: msgBuffer.readableBytes - 1, encoding: .utf8) else {
+                throw  DockerLogDecodingError.dataCorrupted("Unable to parse log message as String")
+            }
+            
+            logEntries.append(
+                DockerLogEntry(source: .stdout, timestamp: timestamp, message: message)
+            )
+        }
+        return logEntries
+    }
+}

--- a/Sources/DockerClientSwift/Endpoints/Containers/ContainerAttachEndpoint.swift
+++ b/Sources/DockerClientSwift/Endpoints/Containers/ContainerAttachEndpoint.swift
@@ -17,7 +17,7 @@ class ContainerAttachEndpoint {
 
     var path: String {
         """
-        containers/\(containerId)/attach/ws\
+        containers/\(nameOrId)/attach/ws\
         ?stdin=\(stdin)\
         &stdout=\(stdout)\
         &stderr=\(stderr)\
@@ -34,74 +34,4 @@ class ContainerAttachEndpoint {
         self.stderr = stderr
     }
     
-
-    /// Extracts a log entry/line for a container not having a TTY
-    private func getEntryNoTty(buffer: inout ByteBuffer, timestamps: Bool) throws -> DockerLogEntry {
-        let timestampLen = timestamps ? 31 : 0
-        
-        guard let sourceRaw: UInt8 = buffer.readInteger(endianness: .big, as: UInt8.self) else {
-            throw DockerLogDecodingError.dataCorrupted("Unable to read log entry source stream header")
-        }
-        let msgSource = DockerLogEntry.Source.init(rawValue: sourceRaw) ?? .stdout
-        let _ = buffer.readBytes(length: 3) // 3 unused bytes
-        
-        guard let msgSize: UInt32 = buffer.readInteger(endianness: .big, as: UInt32.self) else {
-            throw DockerLogDecodingError.dataCorrupted("Unable to read log size header")
-        }
-        
-        guard msgSize > 0 else {
-            throw DockerLogDecodingError.noMessageFound
-        }
-        if buffer.readableBytes < msgSize {
-            // TODO: does this happen during normal logs streaming behavior?
-            throw DockerLogDecodingError.dataCorrupted("Readable bytes (\(buffer.readableBytes)) is less than msgSize (\(msgSize))")
-        }
-        
-        var timestamp: Date? = nil
-        var msgBuffer = ByteBuffer.init(bytes: buffer.readBytes(length: Int(msgSize))!)
-        if timestamps {
-            guard let timestampRaw = msgBuffer.readString(length: timestampLen, encoding: .utf8) else {
-                throw DockerLogDecodingError.noTimestampFound
-            }
-            guard let timestampTry = GetContainerLogsEndpoint.formatter.date(from: String(timestampRaw)) else {
-                throw DockerLogDecodingError.timestampCorrupted
-            }
-            timestamp = timestampTry
-        }
-        guard let message = msgBuffer.readString(length: msgBuffer.readableBytes - 1, encoding: .utf8) else {
-            throw  DockerLogDecodingError.dataCorrupted("Unable to parse log message as String")
-        }
-        
-        return DockerLogEntry(source: msgSource, timestamp: timestamp, message: message)
-    }
-    
-    /// Extracts a log entry/line for a container having a TTY
-    private func getEntryTty(buffer: inout ByteBuffer, timestamps: Bool) throws -> [DockerLogEntry] {
-        let timestampLen = timestamps ? 31 : 0
-        var logEntries: [DockerLogEntry] = []
-        
-        let data = buffer.readData(length: buffer.readableBytes)!
-        let lines = data.split(separator: 10 /* ascii code for \n */)
-        for line in lines {
-            var timestamp: Date? = nil
-            var msgBuffer = ByteBuffer(data: line)
-            if timestamps {
-                guard let timestampRaw = msgBuffer.readString(length: timestampLen, encoding: .utf8) else {
-                    throw DockerLogDecodingError.noTimestampFound
-                }
-                guard let timestampTry = GetContainerLogsEndpoint.formatter.date(from: String(timestampRaw)) else {
-                    throw DockerLogDecodingError.timestampCorrupted
-                }
-                timestamp = timestampTry
-            }
-            guard let message = msgBuffer.readString(length: msgBuffer.readableBytes - 1, encoding: .utf8) else {
-                throw  DockerLogDecodingError.dataCorrupted("Unable to parse log message as String")
-            }
-            
-            logEntries.append(
-                DockerLogEntry(source: .stdout, timestamp: timestamp, message: message)
-            )
-        }
-        return logEntries
-    }
 }

--- a/Sources/DockerClientSwift/Endpoints/Containers/ContainerAttachEndpoint.swift
+++ b/Sources/DockerClientSwift/Endpoints/Containers/ContainerAttachEndpoint.swift
@@ -3,34 +3,42 @@ import NIOHTTP1
 import WebSocketKit
 import Foundation
 
-class ContainerAttachEndpoint {
+/// Attach to a container via Websocket
+final class ContainerAttachEndpoint {
     typealias Body = NoBody
-    typealias Response = AsyncThrowingStream<ByteBuffer, Error>
+    typealias Response = ContainerAttach //AsyncThrowingStream<ByteBuffer, Error>
     
-    var method: HTTPMethod = .GET
-    
+    private var method: HTTPMethod = .GET
+    private var path: String {
+        "containers/\(nameOrId)/attach/ws"
+    }
+
     private let dockerClient: DockerClient
     private let nameOrId: String
     private let stream: Bool
-    private let logs: Bool = true
-    private let stdin: Bool
+    private let logs: Bool
+    private let detachKeys: String?
+    /*private let stdin: Bool = true
     private let stdout: Bool
-    private let stderr: Bool
+    private let stderr: Bool*/
     private var ws: WebSocket?
 
-    var path: String {
+    private var query: String {
         """
-        containers/\(nameOrId)/attach/ws
+        stream=\(stream)\
+        &logs=\(logs)\
+        \(detachKeys != nil ? "&detachKeys=\(detachKeys!)" : "")
         """
     }
-
-    var query: String {
+    
+    /*var query: String {
         """
-        ?stdin=\(stdin)\
+        stdin=\(stdin)\
         &stdout=\(stdout)\
         &stderr=\(stderr)\
         &stream=\(stream)\
-        &logs=\(logs)
+        &logs=\(logs)\
+        \(detachKeys != nil ? "&detachKeys=\(detachKeys!)" : "")
         """
     }
     
@@ -41,57 +49,61 @@ class ContainerAttachEndpoint {
         self.stdin = stdin
         self.stdout = stdout
         self.stderr = stderr
+    }*/
+    
+    init(client: DockerClient, nameOrId: String, stream: Bool, logs: Bool, detachKeys: String? = nil) {
+        self.dockerClient = client
+        self.nameOrId = nameOrId
+        self.stream = stream
+        self.logs = logs
+        self.detachKeys = detachKeys
     }
     
-    func connect() async throws {
+    func connect() async throws -> ContainerAttach {
         let config = WebSocketClient.Configuration(tlsConfiguration: self.dockerClient.tlsConfig)
         
-        /*let endpoint = """
-        \(self.dockerClient.deamonURL.scheme == "https" ? "wss" : "ws")://\
-        \(self.dockerClient.deamonURL.host ?? self.dockerClient.deamonURL.path):\
-        \(self.dockerClient.deamonURL.port ?? (self.dockerClient.deamonURL.scheme == "https" ? 2376 : 2375))\
-        \(self.dockerClient.deamonURL.path)/\(self.dockerClient.apiVersion)/\(self.path)
-        ?\(self.query)
-        """
-        try await WebSocket.connect(
-            to: endpoint,
-            headers: [:],
-            configuration: config,
-            on: elg
-        ) { ws in
-            self.ws = ws
-        }*/
-        print("\n••• SCHEME: \(self.dockerClient.deamonURL.scheme == "https" ? "wss" : "ws")")
+        let scheme = self.dockerClient.deamonURL.scheme
+        guard scheme == "http" || scheme == "https" else {
+            throw DockerError.unsupportedScheme("Attach only supports connecting to docker daemons via HTTP or HTTPS")
+        }
+        /*print("\n••• SCHEME: \(self.dockerClient.deamonURL.scheme == "https" ? "wss" : "ws")")
         print("\n••• HOST: \(self.dockerClient.deamonURL.host ?? self.dockerClient.deamonURL.path)")
-        print("\n••• PATH: \(self.dockerClient.deamonURL.path)/\(self.dockerClient.apiVersion)/\(self.path)")
-        try await WebSocket.connect(
-            scheme: self.dockerClient.deamonURL.scheme == "https" ? "wss" : "ws",
-            host: self.dockerClient.deamonURL.host ?? self.dockerClient.deamonURL.path,
-            port: self.dockerClient.deamonURL.port ?? (self.dockerClient.deamonURL.scheme == "https" ? 2376 : 2375),
-            path: "\(self.dockerClient.deamonURL.path)/\(self.dockerClient.apiVersion)/\(self.path)",
-            query: self.query,
-            headers: [:],
-            configuration: config,
-            on: self.dockerClient.client.eventLoopGroup
-        ) { ws async in
-            print("\n••• CONNECTED?")
-            self.ws = ws
-            //try await ws.send("hello")
-            ws.onBinary { ws, buffer in
-                let rawData = String(data: Data(buffer: buffer), encoding: .utf8)
-                print("\n••••••• BUFFER=\(rawData!) ")
+        print("\n••• PATH: \(self.dockerClient.deamonURL.path)/\(self.dockerClient.apiVersion)/\(self.path)")*/
+        let output = AsyncThrowingStream<String, Error> { continuation in
+            Task {
+                try await WebSocket.connect(
+                    scheme: scheme == "https" ? "wss" : "ws",
+                    host: self.dockerClient.deamonURL.host ?? self.dockerClient.deamonURL.path,
+                    port: self.dockerClient.deamonURL.port ?? (self.dockerClient.deamonURL.scheme == "https" ? 2376 : 2375),
+                    path: "\(self.dockerClient.deamonURL.path)/\(self.dockerClient.apiVersion)/\(self.path)",
+                    query: self.query,
+                    headers: [:],
+                    configuration: config,
+                    on: self.dockerClient.client.eventLoopGroup
+                ) { ws async in
+                    
+                    self.ws = ws
+                    ws.onBinary { ws, buffer in
+                        guard let rawData = String(data: Data(buffer: buffer), encoding: .utf8) else {
+                            continuation.finish(throwing: DockerError.corruptedData("Could not decode Attach output as String"))
+                            return
+                        }
+                        continuation.yield(rawData)
+                    }
+                }
             }
         }
-        
+        return ContainerAttach(attach: self, output: output)
     }
     
     func send(_ text: String) async throws {
         guard let ws = self.ws else {
-            throw DockerError.message("Not connected")
+            throw DockerError.notconnected
+        }
+        guard !ws.isClosed else {
+            throw DockerError.notconnected
         }
         
-        try await ws.send(text)
-        //try await ws.send(Array(text.utf8))
+        try await ws.send(text + "\n")
     }
-    
 }

--- a/Sources/DockerClientSwift/Endpoints/Containers/ContainerAttachEndpoint.swift
+++ b/Sources/DockerClientSwift/Endpoints/Containers/ContainerAttachEndpoint.swift
@@ -9,29 +9,53 @@ class ContainerAttachEndpoint {
     
     var method: HTTPMethod = .GET
     
+    private let dockerClient: DockerClient
     private let nameOrId: String
-    let stream: Bool
-    let stdin: Bool
-    let stdout: Bool
-    let stderr: Bool
+    private let stream: Bool
+    private let stdin: Bool
+    private let stdout: Bool
+    private let stderr: Bool
+    private var ws: WebSocket?
 
     var path: String {
         """
-        containers/\(nameOrId)/attach/ws\
-        ?stdin=\(stdin)\
+        containers/\(nameOrId)/attach/ws
+        """
+    }
+
+    var query: String {
+        """
+        stdin=\(stdin)\
         &stdout=\(stdout)\
         &stderr=\(stderr)\
         &stream=\(stream)
         """
     }
-
     
-    init(nameOrId: String, stream: Bool, stdin: Bool, stdout: Bool, stderr: Bool) {
+    init(client: DockerClient, nameOrId: String, stream: Bool, stdin: Bool, stdout: Bool, stderr: Bool) {
+        self.dockerClient = client
         self.nameOrId = nameOrId
         self.stream = stream
         self.stdin = stdin
         self.stdout = stdout
         self.stderr = stderr
+    }
+    
+    func connect(elg: EventLoopGroup) async throws {
+        let config = WebSocketClient.Configuration.init(tlsConfiguration: self.dockerClient.tlsConfig)
+        WebSocket.connect(
+            scheme: self.dockerClient.deamonURL.scheme == "https" ? "wss" : "ws",
+            host: self.dockerClient.deamonURL.host ?? self.dockerClient.deamonURL.path,
+            port: self.dockerClient.deamonURL.port ?? (self.dockerClient.deamonURL.scheme == "https" ? 2376 : 2375),
+            path: "\(self.dockerClient.deamonURL.path)/\(self.dockerClient.apiVersion)/\(self.path)",
+            query: self.query,
+            headers: [:],
+            configuration: config,
+            on: elg
+        ) { ws in
+            self.ws = ws
+        }
+        
     }
     
 }

--- a/Sources/DockerClientSwift/Endpoints/Containers/GetContainerLogsEndpoint.swift
+++ b/Sources/DockerClientSwift/Endpoints/Containers/GetContainerLogsEndpoint.swift
@@ -60,7 +60,7 @@ class GetContainerLogsEndpoint: StreamingEndpoint {
                         }
                         if tty {
                             do {
-                                for entry in try getEntryTty(buffer: &buffer, timestamps: timestamps) {
+                                for entry in try DockerStream.getEntryTty(buffer: &buffer, timestamps: timestamps) {
                                     continuation.yield(entry)
                                 }
                             }
@@ -71,7 +71,7 @@ class GetContainerLogsEndpoint: StreamingEndpoint {
                         }
                         else {
                             do {
-                                let entry = try getEntryNoTty(buffer: &buffer, timestamps: timestamps)
+                                let entry = try DockerStream.getEntryNoTty(buffer: &buffer, timestamps: timestamps)
                                 continuation.yield(entry)
                             }
                             catch (let error) {
@@ -85,75 +85,5 @@ class GetContainerLogsEndpoint: StreamingEndpoint {
                 continuation.finish()
             }
         }
-    }
-    
-    /// Extracts a log entry/line for a container not having a TTY
-    private func getEntryNoTty(buffer: inout ByteBuffer, timestamps: Bool) throws -> DockerLogEntry {
-        let timestampLen = timestamps ? 31 : 0
-        
-        guard let sourceRaw: UInt8 = buffer.readInteger(endianness: .big, as: UInt8.self) else {
-            throw DockerLogDecodingError.dataCorrupted("Unable to read log entry source stream header")
-        }
-        let msgSource = DockerLogEntry.Source.init(rawValue: sourceRaw) ?? .stdout
-        let _ = buffer.readBytes(length: 3) // 3 unused bytes
-        
-        guard let msgSize: UInt32 = buffer.readInteger(endianness: .big, as: UInt32.self) else {
-            throw DockerLogDecodingError.dataCorrupted("Unable to read log size header")
-        }
-        
-        guard msgSize > 0 else {
-            throw DockerLogDecodingError.noMessageFound
-        }
-        if buffer.readableBytes < msgSize {
-            // TODO: does this happen during normal logs streaming behavior?
-            throw DockerLogDecodingError.dataCorrupted("Readable bytes (\(buffer.readableBytes)) is less than msgSize (\(msgSize))")
-        }
-        
-        var timestamp: Date? = nil
-        var msgBuffer = ByteBuffer.init(bytes: buffer.readBytes(length: Int(msgSize))!)
-        if timestamps {
-            guard let timestampRaw = msgBuffer.readString(length: timestampLen, encoding: .utf8) else {
-                throw DockerLogDecodingError.noTimestampFound
-            }
-            guard let timestampTry = GetContainerLogsEndpoint.formatter.date(from: String(timestampRaw)) else {
-                throw DockerLogDecodingError.timestampCorrupted
-            }
-            timestamp = timestampTry
-        }
-        guard let message = msgBuffer.readString(length: msgBuffer.readableBytes - 1, encoding: .utf8) else {
-            throw  DockerLogDecodingError.dataCorrupted("Unable to parse log message as String")
-        }
-        
-        return DockerLogEntry(source: msgSource, timestamp: timestamp, message: message)
-    }
-    
-    /// Extracts a log entry/line for a container having a TTY
-    private func getEntryTty(buffer: inout ByteBuffer, timestamps: Bool) throws -> [DockerLogEntry] {
-        let timestampLen = timestamps ? 31 : 0
-        var logEntries: [DockerLogEntry] = []
-        
-        let data = buffer.readData(length: buffer.readableBytes)!
-        let lines = data.split(separator: 10 /* ascii code for \n */)
-        for line in lines {
-            var timestamp: Date? = nil
-            var msgBuffer = ByteBuffer(data: line)
-            if timestamps {
-                guard let timestampRaw = msgBuffer.readString(length: timestampLen, encoding: .utf8) else {
-                    throw DockerLogDecodingError.noTimestampFound
-                }
-                guard let timestampTry = GetContainerLogsEndpoint.formatter.date(from: String(timestampRaw)) else {
-                    throw DockerLogDecodingError.timestampCorrupted
-                }
-                timestamp = timestampTry
-            }
-            guard let message = msgBuffer.readString(length: msgBuffer.readableBytes - 1, encoding: .utf8) else {
-                throw  DockerLogDecodingError.dataCorrupted("Unable to parse log message as String")
-            }
-            
-            logEntries.append(
-                DockerLogEntry(source: .stdout, timestamp: timestamp, message: message)
-            )
-        }
-        return logEntries
     }
 }

--- a/Sources/DockerClientSwift/Helper/DockerStream.swift
+++ b/Sources/DockerClientSwift/Helper/DockerStream.swift
@@ -1,0 +1,74 @@
+import Foundation
+import NIO
+
+struct DockerStream {
+    /// Extracts a log entry/line for a container not having a TTY
+    static func getEntryNoTty(buffer: inout ByteBuffer, timestamps: Bool) throws -> DockerLogEntry {
+        let timestampLen = timestamps ? 31 : 0
+        
+        guard let sourceRaw: UInt8 = buffer.readInteger(endianness: .big, as: UInt8.self) else {
+            throw DockerLogDecodingError.dataCorrupted("Unable to read log entry source stream header")
+        }
+        let msgSource = DockerLogEntry.Source.init(rawValue: sourceRaw) ?? .stdout
+        let _ = buffer.readBytes(length: 3) // 3 unused bytes
+        
+        guard let msgSize: UInt32 = buffer.readInteger(endianness: .big, as: UInt32.self) else {
+            throw DockerLogDecodingError.dataCorrupted("Unable to read log size header")
+        }
+        
+        guard msgSize > 0 else {
+            throw DockerLogDecodingError.noMessageFound
+        }
+        if buffer.readableBytes < msgSize {
+            // TODO: does this happen during normal logs streaming behavior?
+            throw DockerLogDecodingError.dataCorrupted("Readable bytes (\(buffer.readableBytes)) is less than msgSize (\(msgSize))")
+        }
+        
+        var timestamp: Date? = nil
+        var msgBuffer = ByteBuffer.init(bytes: buffer.readBytes(length: Int(msgSize))!)
+        if timestamps {
+            guard let timestampRaw = msgBuffer.readString(length: timestampLen, encoding: .utf8) else {
+                throw DockerLogDecodingError.noTimestampFound
+            }
+            guard let timestampTry = GetContainerLogsEndpoint.formatter.date(from: String(timestampRaw)) else {
+                throw DockerLogDecodingError.timestampCorrupted
+            }
+            timestamp = timestampTry
+        }
+        guard let message = msgBuffer.readString(length: msgBuffer.readableBytes - 1, encoding: .utf8) else {
+            throw  DockerLogDecodingError.dataCorrupted("Unable to parse log message as String")
+        }
+        
+        return DockerLogEntry(source: msgSource, timestamp: timestamp, message: message)
+    }
+    
+    /// Extracts a log entry/line for a container having a TTY
+    static func getEntryTty(buffer: inout ByteBuffer, timestamps: Bool) throws -> [DockerLogEntry] {
+        let timestampLen = timestamps ? 31 : 0
+        var logEntries: [DockerLogEntry] = []
+        
+        let data = buffer.readData(length: buffer.readableBytes)!
+        let lines = data.split(separator: 10 /* ascii code for \n */)
+        for line in lines {
+            var timestamp: Date? = nil
+            var msgBuffer = ByteBuffer(data: line)
+            if timestamps {
+                guard let timestampRaw = msgBuffer.readString(length: timestampLen, encoding: .utf8) else {
+                    throw DockerLogDecodingError.noTimestampFound
+                }
+                guard let timestampTry = GetContainerLogsEndpoint.formatter.date(from: String(timestampRaw)) else {
+                    throw DockerLogDecodingError.timestampCorrupted
+                }
+                timestamp = timestampTry
+            }
+            guard let message = msgBuffer.readString(length: msgBuffer.readableBytes - 1, encoding: .utf8) else {
+                throw  DockerLogDecodingError.dataCorrupted("Unable to parse log message as String")
+            }
+            
+            logEntries.append(
+                DockerLogEntry(source: .stdout, timestamp: timestamp, message: message)
+            )
+        }
+        return logEntries
+    }
+}

--- a/Sources/DockerClientSwift/Models/Container/ContainerAttach.swift
+++ b/Sources/DockerClientSwift/Models/Container/ContainerAttach.swift
@@ -1,0 +1,20 @@
+import Foundation
+import NIO
+import WebSocketKit
+
+
+/// Gives access to the output and the standard input of an attached container.
+public final class ContainerAttach {
+    public let output: AsyncThrowingStream<String, Error>
+    
+    private let attachEndpoint: ContainerAttachEndpoint
+    
+    public func send(_ text: String) async throws {
+        try await self.attachEndpoint.send(text)
+    }
+    
+    internal init(attach: ContainerAttachEndpoint, output: AsyncThrowingStream<String, Error>) {
+        self.attachEndpoint = attach
+        self.output = output
+    }
+}

--- a/Sources/DockerClientSwift/Models/Container/ContainerConfig.swift
+++ b/Sources/DockerClientSwift/Models/Container/ContainerConfig.swift
@@ -1,11 +1,12 @@
 import Foundation
 
 public struct ContainerConfig: Codable {
-    public var attachStderr: Bool = true
     
     public var attachStdin: Bool = false
     
     public var attachStdout: Bool = true
+    
+    public var attachStderr: Bool = true
     
     /// Custom command to run, overrides the value of the Image if any
     public var command: [String]? = nil

--- a/Sources/DockerClientSwift/Models/Utilitities.swift
+++ b/Sources/DockerClientSwift/Models/Utilitities.swift
@@ -26,9 +26,13 @@ extension Digest: ExpressibleByStringLiteral {
 extension Digest: Codable {}
 
 public enum DockerError: Error {
+    /// Not connected to an Attach/Exec endpoint, or disconnected
+    case notconnected
+    /// Custom error from the Docker daemon
     case message(String)
     case unknownResponse(String)
     case corruptedData(String)
     case errorCode(Int, String?)
+    case unsupportedScheme(String)
 }
 

--- a/Tests/DockerClientTests/ContainerTests.swift
+++ b/Tests/DockerClientTests/ContainerTests.swift
@@ -15,7 +15,7 @@ final class ContainerTests: XCTestCase {
     }
     
     
-    func testattach() async throws {
+    func testAttach() async throws {
         let image = try await client.images.get("nginx:latest")
         let container = try await client.containers.create(image: image)
         try await client.containers.start(container.id)

--- a/Tests/DockerClientTests/ContainerTests.swift
+++ b/Tests/DockerClientTests/ContainerTests.swift
@@ -14,8 +14,24 @@ final class ContainerTests: XCTestCase {
         try client.syncShutdown()
     }
     
+    
+    func testattach() async throws {
+        let image = try await client.images.get("nginx:latest")
+        let container = try await client.containers.create(image: image)
+        try await client.containers.start(container.id)
+        let ep = ContainerAttachEndpoint(client: client, nameOrId: container.id, stream: true, stdin: true, stdout: true, stderr: true)
+        do {
+        try await ep.connect()
+        print("\n••• before sleep")
+        try await Task.sleep(nanoseconds: 5_000_000_000)
+        }
+        catch(let error) {
+            print("\n••••• BOOM! \(error)")
+        }
+    }
+    
     func testCreateContainer() async throws {
-        //let _ = try await client.images.pull(byName: "hello-world", tag: "latest")
+        let _ = try await client.images.pull(byName: "hello-world", tag: "latest")
         let memory: UInt64 = 64 * 1024 * 1024
         let spec = ContainerSpec(
             config: .init(

--- a/Tests/DockerClientTests/ServiceTests.swift
+++ b/Tests/DockerClientTests/ServiceTests.swift
@@ -71,8 +71,7 @@ final class ServiceTests: XCTestCase {
         let service = try await client.services.create(spec: spec)
         
         spec.mode = .replicated(2)
-        try await client.services.update(service: service, version: service.version.index, spec: spec)
-        let updated = try await client.services.get(service.id)
+        let updated = try await client.services.update(service: service, version: service.version.index, spec: spec)
         
         XCTAssertTrue(updated.version.index > service.version.index)
         XCTAssert(

--- a/Tests/DockerClientTests/Utils/DockerClient+Testable.swift
+++ b/Tests/DockerClientTests/Utils/DockerClient+Testable.swift
@@ -11,10 +11,10 @@ extension DockerClient {
         logger.logLevel = .debug
         
         // Local Unix socket
-        return DockerClient(logger: logger)
+        //return DockerClient(logger: logger)
         
         // Remote via simple HTTP
-        //return DockerClient(deamonURL: .init(string: "http://127.0.0.1:2375")!, logger: logger)
+        return DockerClient(deamonURL: .init(string: "http://127.0.0.1:2375")!, logger: logger)
         
         // Remote daemon, using HTTPS and client certs authentication
         /*var tlsConfig = TLSConfiguration.makeClientConfiguration()

--- a/Tests/DockerClientTests/Utils/DockerClient+Testable.swift
+++ b/Tests/DockerClientTests/Utils/DockerClient+Testable.swift
@@ -14,10 +14,10 @@ extension DockerClient {
         //return DockerClient(logger: logger)
         
         // Remote via simple HTTP
-        return DockerClient(deamonURL: .init(string: "http://127.0.0.1:2375")!, logger: logger)
+        //return DockerClient(deamonURL: .init(string: "http://127.0.0.1:2375")!, logger: logger)
         
         // Remote daemon, using HTTPS and client certs authentication
-        /*var tlsConfig = TLSConfiguration.makeClientConfiguration()
+        var tlsConfig = TLSConfiguration.makeClientConfiguration()
         tlsConfig.privateKey = NIOSSLPrivateKeySource.file("client-key.pem")
         tlsConfig.certificateChain.append(NIOSSLCertificateSource.file("client-certificate.pem"))
         tlsConfig.additionalTrustRoots.append(.file("ca-public.pem"))
@@ -26,6 +26,6 @@ extension DockerClient {
             deamonURL: .init(string: "https://51.15.19.7:2376")!,
             tlsConfig: tlsConfig,
             logger: logger
-        )*/
+        )
     }
 }


### PR DESCRIPTION
Add (very) basic support for attaching to a Container.

This is only supported when connecting to a remote Docker daemon over HTTP/HTTPS. Unix sockets are not supported at the moment, due to limitations in the Websocket-kit library.