### PR TITLE
More reliable way to check if a Serice or Task has a tty when determining logs format

### DIFF
--- a/Sources/DockerClientSwift/APIs/DockerClient+Task.swift
+++ b/Sources/DockerClientSwift/APIs/DockerClient+Task.swift
@@ -48,12 +48,22 @@ extension DockerClient {
                 since: since,
                 until: until
             )
+            
+            var tty: Bool!
+            if let hasTty = task.spec.containerSpec.tty {
+                tty = hasTty
+            }
+            else {
+                let image = try await self.client.images.get(task.spec.containerSpec.image)
+                tty = image.containerConfig.tty
+            }
+            
             let response = try await client.run(
                 endpoint,
                 // Arbitrary timeouts.
                 // TODO: should probably make these configurable
                 timeout: follow ? .hours(12) : .seconds(60),
-                hasLengthHeader: !(task.spec.containerSpec.tty ?? false)
+                hasLengthHeader: !tty
             )
             return try await endpoint.map(response: response, tty: task.spec.containerSpec.tty ?? false)
         }


### PR DESCRIPTION
If we can't determine whether the Service or Task containers have a TTY from the Service or Task info, we default to the value contained in the Image config.
This requires an extra API call to get the Image details.
https://github.com/m-barthelemy/docker-client-swift/issues/1